### PR TITLE
Support unicode heading and GitHub style anchor link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Allow you to enable/disable the anchor link in the headings
 
 Allow you to customize the anchor link symbol
 
-#### `anchorLinkSymbolSpace`
+#### `anchorLinkSpace`
 
 (default: `true`)
 
-Allow you to enable/disable inserting a space between the anchor symbol and heading.
+Allow you to enable/disable inserting a space between the anchor link and heading.
 
 #### `anchorLinkSymbolClassName`
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ Allow you to enable/disable the anchor link in the headings
 
 Allow you to customize the anchor link symbol
 
+#### `anchorLinkSymbolSpace`
+
+(default: `true`)
+
+Allow you to enable/disable inserting a space between the anchor symbol and heading.
+
+#### `anchorLinkSymbolClassName`
+
+(default: `null`)
+
+Allow you to customize the anchor link symbol class name. If not null, symbol will be rendered as `<span class="anchorLinkSymbolClassName">anchorLinkSymbol</span>`.
+
 #### `anchorLinkBefore`
 
 (default: `true`)

--- a/__tests__/toc.js
+++ b/__tests__/toc.js
@@ -76,7 +76,7 @@ tape("markdown-it-toc-and-anchor toc", (t) => {
         anchorClassName: "anchor",
         anchorLinkSymbol: "",
         anchorLinkSymbolClassName: "octicon octicon-link",
-        anchorLinkSymbolSpace: false,
+        anchorLinkSpace: false,
       }
     ),
     `<p>

--- a/__tests__/toc.js
+++ b/__tests__/toc.js
@@ -50,6 +50,31 @@ tape("markdown-it-toc-and-anchor toc", (t) => {
   t.equal(
     mdIt(
       `@[toc]
+# Heading`,
+      {
+        toc: true,
+        anchorLink: true,
+        anchorClassName: "anchor",
+        anchorLinkSymbol: "",
+        anchorLinkSymbolClassName: "octicon octicon-link",
+        anchorLinkSymbolSpace: false,
+      }
+    ),
+    `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading"><a class="anchor" href="#heading">` +
+    `<span class="octicon octicon-link"></span></a>Heading</h1>\n`,
+    "should support GitHub style anchor link"
+  )
+
+  t.equal(
+    mdIt(
+      `@[toc]
 # Heading
 ## Two
 ### Three

--- a/__tests__/toc.js
+++ b/__tests__/toc.js
@@ -50,6 +50,25 @@ tape("markdown-it-toc-and-anchor toc", (t) => {
   t.equal(
     mdIt(
       `@[toc]
+# 新年快乐`,
+      {
+        toc: true,
+      }
+    ),
+    `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#新年快乐">新年快乐</a>
+  </li>
+</ul>
+</p>
+<h1 id="新年快乐">新年快乐</h1>\n`,
+    "should support unicode headings"
+  )
+
+  t.equal(
+    mdIt(
+      `@[toc]
 # Heading`,
       {
         toc: true,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "repository": "https://github.com/MoOx/markdown-it-toc-and-anchor.git",
   "main": "dist/index.js",
   "dependencies": {
-    "markdown-it": "^5.0.0"
+    "markdown-it": "^5.0.0",
+    "uslug": "^1.0.3"
   },
   "devDependencies": {
     "babel": "^5.4.7",

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ const renderAnchorLink = (anchor, options, tokens, idx) => {
   }
 
   // insert space between symbol and heading ?
-  if (options.anchorLinkSymbolSpace) {
+  if (options.anchorLinkSpace) {
     linkTokens[actionOnArray[!options.anchorLinkBefore]](space())
   }
   tokens[idx + 1].children[
@@ -117,7 +117,7 @@ export default function(md, options) {
     anchorClassName: "markdownIt-Anchor",
     resetIds: true,
     indentation: "  ",
-    anchorLinkSymbolSpace: true,
+    anchorLinkSpace: true,
     anchorLinkSymbolClassName: null,
     ...options,
   }

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ const renderAnchorLink = (anchor, options, tokens, idx) => {
     true: "unshift",
   }
 
-  // insert space between symbol and heading ?
+  // insert space between anchor link and heading ?
   if (options.anchorLinkSpace) {
     linkTokens[actionOnArray[!options.anchorLinkBefore]](space())
   }

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,32 @@ const space = () => {
   return {...(new Token("text", "", 0)), content: " "}
 }
 
+const renderAnchorLinkSymbol = (options) => {
+  if (options.anchorLinkSymbolClassName) {
+    return [
+      {
+        ...(new Token("span_open", "span", 1)),
+        attrs: [
+          ["class", options.anchorLinkSymbolClassName],
+        ],
+      },
+      {
+        ...(new Token("text", "", 0)),
+        content: options.anchorLinkSymbol,
+      },
+      new Token("span_close", "span", -1),
+    ]
+  }
+  else {
+    return [
+      {
+      ...(new Token("text", "", 0)),
+      content: options.anchorLinkSymbol,
+      },
+    ]
+  }
+}
+
 const renderAnchorLink = (anchor, options, tokens, idx) => {
   const linkTokens = [
     {
@@ -43,10 +69,7 @@ const renderAnchorLink = (anchor, options, tokens, idx) => {
         ["href", `#${anchor}`],
       ],
     },
-    {
-      ...(new Token("text", "", 0)),
-      content: options.anchorLinkSymbol,
-    },
+    ...(renderAnchorLinkSymbol(options)),
     new Token("link_close", "a", -1),
   ]
 
@@ -56,7 +79,11 @@ const renderAnchorLink = (anchor, options, tokens, idx) => {
     false: "push",
     true: "unshift",
   }
-  linkTokens[actionOnArray[!options.anchorLinkBefore]](space())
+
+  // insert space between symbol and heading ?
+  if (options.anchorLinkSymbolSpace) {
+    linkTokens[actionOnArray[!options.anchorLinkBefore]](space())
+  }
   tokens[idx + 1].children[
     actionOnArray[options.anchorLinkBefore]
   ](...linkTokens)
@@ -90,6 +117,8 @@ export default function(md, options) {
     anchorClassName: "markdownIt-Anchor",
     resetIds: true,
     indentation: "  ",
+    anchorLinkSymbolSpace: true,
+    anchorLinkSymbolClassName: null,
     ...options,
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import Token from "markdown-it/lib/token"
+import uslug from "uslug"
 
 var TOC = "@[toc]"
 var TOC_RE = /^@\[toc\]/im
@@ -8,15 +9,7 @@ let headingIds = {}
 const repeat = (string, num) => new Array(num + 1).join(string)
 
 const makeSafe = (string) => {
-  const key = string
-    // url in lower case are cool
-    .toLowerCase()
-
-    // dashify
-    .replace(/\W+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "")
-
+  const key = uslug(string) // slugify
   if (!headingIds[key]) {
     headingIds[key] = 0
   }


### PR DESCRIPTION
Fixed:

1. https://github.com/MoOx/markdown-it-toc-and-anchor/issues/3
2. https://github.com/MoOx/markdown-it-toc-and-anchor/issues/5