### PR TITLE
Reset ids

### DIFF
--- a/src/__tests__/toc.js
+++ b/src/__tests__/toc.js
@@ -242,4 +242,106 @@ test("markdown-it-toc-and-anchor toc", (t) => {
 <h3 id="deeper-heading">Deeper Heading</h3>\n`,
     "should works"
   )
+
+  t.same(
+    mdIt(
+      [`# Heading`, `# Heading`, `# Heading`],
+      { resetIds: true }
+    ),
+    [`<h1 id="heading">Heading</h1>\n`, `<h1 id="heading">Heading</h1>\n`, `<h1 id="heading">Heading</h1>\n`],
+    "should return the same anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is true "
+  )
+
+  t.same(
+    mdIt(
+      [`# Heading`, `# Heading`, `# Heading`],
+      { resetIds: false }
+    ),
+    [`<h1 id="heading">Heading</h1>\n`, `<h1 id="heading-2">Heading</h1>\n`, `<h1 id="heading-3">Heading</h1>\n`],
+    "should return different anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is false "
+  )
+
+  t.same(
+    mdIt(
+      [`@[toc]
+# Heading`,
+       `@[toc]
+# Heading`,
+       `@[toc]
+# Heading`],
+      {
+        toc: true,
+        resetIds: true
+      }
+    ),
+    [
+      `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading">Heading</h1>\n`,
+      `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading">Heading</h1>\n`,
+      `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading">Heading</h1>\n`,
+    ],
+    "should return the same anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is true and toc is true"
+  )
+
+  t.same(
+    mdIt(
+      [`@[toc]
+# Heading`,
+       `@[toc]
+# Heading`,
+       `@[toc]
+# Heading`],
+      {
+        toc: true,
+        resetIds: false
+      }
+    ),
+    [
+      `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading">Heading</h1>\n`,
+      `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading-2">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading-2">Heading</h1>\n`,
+      `<p>
+<ul class="markdownIt-TOC">
+  <li>
+    <a href="#heading-3">Heading</a>
+  </li>
+</ul>
+</p>
+<h1 id="heading-3">Heading</h1>\n`,
+    ],
+    "should return different anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is false and toc is true"
+  )
 })

--- a/src/__tests__/toc.js
+++ b/src/__tests__/toc.js
@@ -245,33 +245,47 @@ test("markdown-it-toc-and-anchor toc", (t) => {
 
   t.same(
     mdIt(
-      [`# Heading`, `# Heading`, `# Heading`],
+      [ `# Heading`, `# Heading`, `# Heading` ],
       { resetIds: true }
     ),
-    [`<h1 id="heading">Heading</h1>\n`, `<h1 id="heading">Heading</h1>\n`, `<h1 id="heading">Heading</h1>\n`],
-    "should return the same anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is true "
+    [
+      `<h1 id="heading">Heading</h1>\n`,
+      `<h1 id="heading">Heading</h1>\n`,
+      `<h1 id="heading">Heading</h1>\n`,
+    ],
+    `should return the same anchor hrefs for the same markdown headings with
+same names on different renderings with the same markdownIt instance when 
+resetIds is true`
   )
 
   t.same(
     mdIt(
-      [`# Heading`, `# Heading`, `# Heading`],
+      [ `# Heading`, `# Heading`, `# Heading` ],
       { resetIds: false }
     ),
-    [`<h1 id="heading">Heading</h1>\n`, `<h1 id="heading-2">Heading</h1>\n`, `<h1 id="heading-3">Heading</h1>\n`],
-    "should return different anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is false "
+    [
+      `<h1 id="heading">Heading</h1>\n`,
+      `<h1 id="heading-2">Heading</h1>\n`,
+      `<h1 id="heading-3">Heading</h1>\n`,
+    ],
+    `should return different anchor hrefs for the same markdown headings with 
+same names on different renderings with the same markdownIt instance when 
+resetIds is false`
   )
 
   t.same(
     mdIt(
-      [`@[toc]
+      [
+        `@[toc]
 # Heading`,
-       `@[toc]
+        `@[toc]
 # Heading`,
-       `@[toc]
-# Heading`],
+        `@[toc]
+# Heading`,
+      ],
       {
         toc: true,
-        resetIds: true
+        resetIds: true,
       }
     ),
     [
@@ -300,20 +314,24 @@ test("markdown-it-toc-and-anchor toc", (t) => {
 </p>
 <h1 id="heading">Heading</h1>\n`,
     ],
-    "should return the same anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is true and toc is true"
+    `should return the same anchor hrefs for the same markdown headings with 
+same names on different renderings with the same markdownIt instance when 
+resetIds is true and toc is true`
   )
 
   t.same(
     mdIt(
-      [`@[toc]
+      [
+        `@[toc]
 # Heading`,
-       `@[toc]
+        `@[toc]
 # Heading`,
-       `@[toc]
-# Heading`],
+        `@[toc]
+# Heading`,
+      ],
       {
         toc: true,
-        resetIds: false
+        resetIds: false,
       }
     ),
     [
@@ -342,6 +360,8 @@ test("markdown-it-toc-and-anchor toc", (t) => {
 </p>
 <h1 id="heading-3">Heading</h1>\n`,
     ],
-    "should return different anchor hrefs for the same markdown headings with same names on different renderings with the same markdownIt instance when resetIds is false and toc is true"
+    `should return different anchor hrefs for the same markdown headings with 
+same names on different renderings with the same markdownIt instance when 
+resetIds is false and toc is true`
   )
 })

--- a/src/__tests__/utils/md-it.js
+++ b/src/__tests__/utils/md-it.js
@@ -22,7 +22,7 @@ export default (md, options = {}) => {
         return mdIt.render(md)
     } else if (md.constructor === Array) {
         for (let s of md) {
-            mdRender.push('' + mdIt.render(s) + '')
+            mdRender.push(mdIt.render(s))
         }
         return mdRender
     }

--- a/src/__tests__/utils/md-it.js
+++ b/src/__tests__/utils/md-it.js
@@ -2,11 +2,11 @@ import markdownIt from "markdown-it"
 import markdownItTocAndAnchor from "../../../src"
 
 export default (md, options = {}) => {
-    const mdIt = markdownIt({
-      html: true,
-      linkify: true,
-      typography: true,
-    })
+  const mdIt = markdownIt({
+    html: true,
+    linkify: true,
+    typography: true,
+  })
     .use(markdownItTocAndAnchor, {
 
       // disable main features
@@ -17,13 +17,14 @@ export default (md, options = {}) => {
       ...options,
     })
 
-    let mdRender = []
-    if (typeof md === "string") {
-        return mdIt.render(md)
-    } else if (md.constructor === Array) {
-        for (let s of md) {
-            mdRender.push(mdIt.render(s))
-        }
-        return mdRender
+  const mdRender = []
+  if (typeof md === "string") {
+    return mdIt.render(md)
+  }
+  else if (md.constructor === Array) {
+    for (const s of md) {
+      mdRender.push(mdIt.render(s))
     }
+    return mdRender
+  }
 }

--- a/src/__tests__/utils/md-it.js
+++ b/src/__tests__/utils/md-it.js
@@ -1,11 +1,12 @@
 import markdownIt from "markdown-it"
 import markdownItTocAndAnchor from "../../../src"
 
-export default (md, options = {}) => markdownIt({
-  html: true,
-  linkify: true,
-  typography: true,
-})
+export default (md, options = {}) => {
+    const mdIt = markdownIt({
+      html: true,
+      linkify: true,
+      typography: true,
+    })
     .use(markdownItTocAndAnchor, {
 
       // disable main features
@@ -15,4 +16,14 @@ export default (md, options = {}) => markdownIt({
 
       ...options,
     })
-    .render(md)
+
+    let mdRender = []
+    if (typeof md === "string") {
+        return mdIt.render(md)
+    } else if (md.constructor === Array) {
+        for (let s of md) {
+            mdRender.push('' + mdIt.render(s) + '')
+        }
+        return mdRender
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -125,19 +125,22 @@ export default function(md, options) {
 
   let gstate
 
+  // reset keys id for each instance
+  headingIds = {}
+
   md.core.ruler.push("grab_state_and_token", function(state) {
     gstate = state
     Token = state.Token
+    // reset keys id for each document
+    if (options.resetIds) {
+      headingIds = {}
+    }
   })
 
   md.inline.ruler.after(
     "emphasis",
     "toc",
     (state, silent) => {
-      // reset keys id for each document
-      if (options.resetIds) {
-        headingIds = {}
-      }
 
       let token
       let match


### PR DESCRIPTION
fixes #8 
added support for arrays in tests to represent multiple calls to the same markdown-it instance,
added corresponding tests