### PR TITLE
Error occurs when uncompleted markdown text is parsed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ export default function(md, options) {
 
       if (heading.type === "inline") {
         let content
-        if (heading.children && heading.children[0].type === "link_open") {
+        if (heading.children.length > 0 && heading.children[0].type === "link_open") {
           // headings that contain links have to be processed
           // differently since nested links aren't allowed in markdown
           content = heading.children[1].content

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ export default function(md, options) {
 
       if (heading.type === "inline") {
         let content
-        if (heading.children.length > 0 && heading.children[0].type === "link_open") {
+        if (heading.children && heading.children.length > 0 && heading.children[0].type === "link_open") {
           // headings that contain links have to be processed
           // differently since nested links aren't allowed in markdown
           content = heading.children[1].content


### PR DESCRIPTION
I didn't find a similar issue but this one fixes my situation. 

If there is only one '#' being parsed, the original code will fail. 