### PR TITLE
migrate from uslug to slug - fix #65

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ documents on the same page.
 
 #### `slugify`
 
-(default: uses the [`uslug`](https://www.npmjs.com/package/uslug) package)
+(default: uses the [`slug`](https://www.npmjs.com/package/slug) package)
 
 Allows you to customize the slug function that create ids from string.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "clone": "^2.1.0",
-    "uslug": "^1.0.4"
+    "slug": "^2.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/__tests__/anchor.js
+++ b/src/__tests__/anchor.js
@@ -15,8 +15,8 @@ test("markdown-it-toc-and-anchor anchor", t => {
     /* eslint-disable max-len */
     `<p></p>
 <h1 id="heading"><a class="markdownIt-Anchor" href="#heading">#</a> 'Heading' ?</h1>
-<h1 id="lel"><a class="markdownIt-Anchor" href="#lel">#</a> $.lel!</h1>
-<h1 id="lel-2"><a class="markdownIt-Anchor" href="#lel-2">#</a> $.lel?</h1>\n`,
+<h1 id="dollarlel"><a class="markdownIt-Anchor" href="#dollarlel">#</a> $.lel!</h1>
+<h1 id="dollarlel-2"><a class="markdownIt-Anchor" href="#dollarlel-2">#</a> $.lel?</h1>\n`,
     /* eslint-enable max-len */
     "should add anchors"
   );
@@ -36,8 +36,8 @@ test("markdown-it-toc-and-anchor anchor", t => {
     /* eslint-disable max-len */
     `<p></p>
 <h1 id="heading">'Heading' ? <a class="markdownIt-Anchor" href="#heading">#</a></h1>
-<h1 id="lel">$.lel! <a class="markdownIt-Anchor" href="#lel">#</a></h1>
-<h1 id="lel-2">$.lel? <a class="markdownIt-Anchor" href="#lel-2">#</a></h1>\n`,
+<h1 id="dollarlel">$.lel! <a class="markdownIt-Anchor" href="#dollarlel">#</a></h1>
+<h1 id="dollarlel-2">$.lel? <a class="markdownIt-Anchor" href="#dollarlel-2">#</a></h1>\n`,
     /* eslint-enable max-len */
     "should add anchors after"
   );

--- a/src/__tests__/toc.js
+++ b/src/__tests__/toc.js
@@ -118,10 +118,10 @@ and next element in the same inline token`
       }
     ),
     `<p><ul class="markdownIt-TOC">
-<li><a href="#%E6%96%B0%E5%B9%B4%E5%BF%AB%E4%B9%90">新年快乐</a></li>
+<li><a href="#5paw5bm05br5lmq">新年快乐</a></li>
 </ul>
 </p>
-<h1 id="新年快乐">新年快乐</h1>\n`,
+<h1 id="5paw5bm05br5lmq">新年快乐</h1>\n`,
     "should support unicode headings"
   );
 
@@ -208,13 +208,13 @@ and next element in the same inline token`
     ),
     `<p><ul class="markdownIt-TOC">
 <li><a href="#heading">'Heading' ?</a></li>
-<li><a href="#lel">$.lel!</a></li>
-<li><a href="#lel-2">$.lel?</a></li>
+<li><a href="#dollarlel">$.lel!</a></li>
+<li><a href="#dollarlel-2">$.lel?</a></li>
 </ul>
 </p>
 <h1 id="heading">'Heading' ?</h1>
-<h1 id="lel">$.lel!</h1>
-<h1 id="lel-2">$.lel?</h1>\n`,
+<h1 id="dollarlel">$.lel!</h1>
+<h1 id="dollarlel-2">$.lel?</h1>\n`,
     "should work with special chars"
   );
 
@@ -312,7 +312,7 @@ and next element in the same inline token`
       '<h1 id="heading">Heading</h1>\n'
     ],
     `should return the same anchor hrefs for the same markdown headings with
-same names on different renderings with the same markdownIt instance when 
+same names on different renderings with the same markdownIt instance when
 resetIds is true`
   );
 
@@ -323,8 +323,8 @@ resetIds is true`
       '<h1 id="heading-2">Heading</h1>\n',
       '<h1 id="heading-3">Heading</h1>\n'
     ],
-    `should return different anchor hrefs for the same markdown headings with 
-same names on different renderings with the same markdownIt instance when 
+    `should return different anchor hrefs for the same markdown headings with
+same names on different renderings with the same markdownIt instance when
 resetIds is false`
   );
 
@@ -360,8 +360,8 @@ resetIds is false`
 </p>
 <h1 id="heading">Heading</h1>\n`
     ],
-    `should return the same anchor hrefs for the same markdown headings with 
-same names on different renderings with the same markdownIt instance when 
+    `should return the same anchor hrefs for the same markdown headings with
+same names on different renderings with the same markdownIt instance when
 resetIds is true and toc is true`
   );
 
@@ -397,8 +397,8 @@ resetIds is true and toc is true`
 </p>
 <h1 id="heading-3">Heading</h1>\n`
     ],
-    `should return different anchor hrefs for the same markdown headings with 
-same names on different renderings with the same markdownIt instance when 
+    `should return different anchor hrefs for the same markdown headings with
+same names on different renderings with the same markdownIt instance when
 resetIds is false and toc is true`
   );
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import clone from "clone";
-import uslug from "uslug";
+import slug from "slug";
 import Token from "markdown-it/lib/token";
 
 const TOC = "@[toc]";
@@ -175,9 +175,15 @@ export default function(md, options) {
     const tocArray = [];
     let tocMarkdown = "";
     let tocTokens = [];
+    const slugify = function(string) {
+      return slug(string, {
+        symbols: true,
+        lower: true
+      });
+    }
 
     const slugifyFn =
-      (typeof options.slugify === "function" && options.slugify) || uslug;
+      (typeof options.slugify === "function" && options.slugify) || slugify;
 
     for (let i = 0; i < tokens.length; i++) {
       if (tokens[i].type !== "heading_close") {


### PR DESCRIPTION
With this change the dependency to `uslug` is removed in favor of `slug`.
The reason is because `uslug` depends on `unorm` which is polluting the license with a GPL 2 restriction.